### PR TITLE
CDPATH support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,20 @@
 
 <h3>CD to a directory super fast</h4>
 
-Typing out a long directory path can be a bit painful. Most tools that solve this problem give you less to type but still involve additional steps afterwards. Instead of tracking frequently visited directories, using a fuzzy search, or even a ML model to improve the cd experience, fastTravelCLI allows you to directly save a destination as a key-value pair, then you can fast travel to that location by just using the key you set. 
+Typing out a long directory path can be a bit painful. Most tools that solve this problem give you less to type but still involve additional steps afterwards. 
+Instead of tracking frequently visited directories, using a fuzzy search, or even a ML model to improve the cd experience, fastTravelCLI allows you to directly save a destination as a key-value pair, then you can fast travel to that location by just using the key you set. 
+fastTravelCLI is a true CD command replacement with additional features. Check out the issues for even more features on the way.
 <br></br>
-fastTravelCLI takes an experience like this: 
+
+Zoxide is a great solution but the implementation is complex leading to many issues that cause it to be less than ideal for many use cases.
+Here are a few examples of issues that fastTravelCLI solves gracefully or avoids entirely.
+https://github.com/ajeetdsouza/zoxide/issues/620 - CDPATH support
+https://github.com/ajeetdsouza/zoxide/issues/876 - Differentiating similarly named directories
+https://github.com/ajeetdsouza/zoxide/issues/839 - Session history stack navigation
+https://github.com/ajeetdsouza/zoxide/issues/863 - Navigation local to project
+
+<br></br>
+If you use fzf to find a deeply nested directory, fastTravelCLI takes an experience like this: 
 ```
 cd $(find * -type d | fzf)
 ```
@@ -50,14 +61,6 @@ ft wknotes
 <br></br>
 
 
-<!-- Zoxide is a great solution but the implementation is complex leading to many issues that cause it to be less than ideal for many use cases. -->
-<!-- Here are a few examples of issues that fastTravelCLI solves gracefully or avoids entirely. -->
-<!-- https://github.com/ajeetdsouza/zoxide/issues/620 - CDPATH support -->
-<!-- https://github.com/ajeetdsouza/zoxide/issues/876 - Differentiating similarly named directories -->
-<!-- https://github.com/ajeetdsouza/zoxide/issues/839 - Session history stack navigation -->
-<!-- https://github.com/ajeetdsouza/zoxide/issues/863 - Navigation local to project -->
-
-<br></br>
 
 <h1>Usage</h1>
 <br></br>
@@ -83,10 +86,10 @@ ft [key]/some/subdir
 ft relative/dir
 ft ..
 ft -
-ft ./dir
-# or
-ft dir/
 
+# ft supports relative paths in the working directory and CDPATH
+
+ft dir
 
 # ft allows you to visit previously visited directories
 

--- a/main_test.go
+++ b/main_test.go
@@ -49,6 +49,29 @@ func TestMainFunc(t *testing.T) {
 		t.Fatalf("Failed to navigate to temp directory")
 	}
 
+	// CDPATH setup
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("Failed to retrieve home directory: %v", err)
+	}
+	cdpathdir, err := os.MkdirTemp(homeDir, "cdpathdir")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	defer os.RemoveAll(cdpathdir)
+
+	cdpathtest, err := os.MkdirTemp(cdpathdir, "cdpathtest")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	cdpathtestkey := filepath.Base(cdpathtest)
+
+	cdpath := os.Getenv("CDPATH")
+	err = os.Setenv("CDPATH", fmt.Sprint(cdpathdir, ":", cdpath))
+
+	// tests
 	tests := []struct {
 		name     string
 		args     []string
@@ -100,6 +123,12 @@ func TestMainFunc(t *testing.T) {
 			name:     "6. Check navigate stack.",
 			args:     []string{"ft", "["},
 			expected: "[\n",
+			wantErr:  false,
+		},
+		{
+			name:     "7. Check cd command with CDPATH.",
+			args:     []string{"ft", cdpathtestkey},
+			expected: fmt.Sprintf("%v\n", cdpathtest),
 			wantErr:  false,
 		},
 		// {


### PR DESCRIPTION
- relative paths in CWD no longer need ./ prefix or / suffix to work.
- fastTravelCLI now respects CDPATH.