### PR TITLE
Y flag

### DIFF
--- a/ft/commands.go
+++ b/ft/commands.go
@@ -46,11 +46,11 @@ func PassCmd(args []string) (*Cmd, error) {
 	case "-help", "-h", "-version", "-v", "-is", "-update", "-u":
 		break
 	case "-rn", "-edit":
-		if len(args) <= 3 {
+		if len(cmd.Args) < 2 {
 			return nil, errors.New(fmt.Sprintf("Insufficient args provided %v, see ft -help for more info", args[1:]))
 		}
 	default:
-		if len(args) <= 2 {
+		if len(cmd.Args) == 0 {
 			return nil, errors.New(fmt.Sprintf("Insufficient args provided %v, usage: ft <command> <path/key>", args[1:]))
 		}
 	}

--- a/ft/commands.go
+++ b/ft/commands.go
@@ -182,7 +182,7 @@ func setDirectoryVar(data *CmdAPI) error {
 		if ok {
 			var res string
 			// if force setting we don't need to read in a response from the user
-			if !data.cmd.Flags.y {
+			if !data.cmd.Flags.Y {
 				fmt.Printf(PathAlreadyExistsMsg, path, k, key)
 				_, err := fmt.Fscan(data.rdr, &res)
 				if err != nil {
@@ -190,7 +190,7 @@ func setDirectoryVar(data *CmdAPI) error {
 				}
 			}
 
-			if overwrite, err := verifyInput(res, data.cmd.Flags.y); !overwrite {
+			if overwrite, err := verifyInput(res, data.cmd.Flags.Y); !overwrite {
 				if err != nil {
 					return err
 				}
@@ -212,7 +212,7 @@ func setDirectoryVar(data *CmdAPI) error {
 		val, ok := data.allPaths[key]
 		if ok {
 			var res string
-			if !data.cmd.Flags.y {
+			if !data.cmd.Flags.Y {
 				// capture user response and act accordingly
 				fmt.Printf(KeyAlreadyExistsMsg, key, val, key)
 				_, err := fmt.Fscan(data.rdr, &res)
@@ -220,7 +220,7 @@ func setDirectoryVar(data *CmdAPI) error {
 					return err
 				}
 			}
-			if overwrite, err := verifyInput(res, data.cmd.Flags.y); !overwrite {
+			if overwrite, err := verifyInput(res, data.cmd.Flags.Y); !overwrite {
 				if err != nil {
 					return err
 				}

--- a/ft/commands_test.go
+++ b/ft/commands_test.go
@@ -12,8 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 // test helpers
@@ -29,6 +27,25 @@ func equalSlices(a, b []string) bool {
 	return true
 }
 
+func equalCmd(got, expected *Cmd) bool {
+	if len(got.Args) != len(expected.Args) {
+		return false
+	}
+	for i, v := range expected.Args {
+		if v != got.Args[i] {
+			return false
+		}
+	}
+	if got.Cmd != expected.Cmd {
+		return false
+	}
+	if got.Flags.Y != expected.Flags.Y {
+		return false
+	}
+
+	return true
+}
+
 // tests
 func TestPassCmd(t *testing.T) {
 	tests := []struct {
@@ -40,7 +57,7 @@ func TestPassCmd(t *testing.T) {
 		{"1. Pass in a path.", []string{"ft", "mypath/dir"}, &Cmd{Cmd: "_", Args: []string{"mypath/dir"}}, false},
 		{"2. Pass in -ls.", []string{"ft", "-ls"}, &Cmd{Cmd: "-ls"}, false},
 		{"3. Pass in -help.", []string{"ft", "-help"}, &Cmd{Cmd: "-help"}, false},
-		{"4. Pass in -rn.", []string{"ft", "-rn", "key", "newKey"}, &Cmd{Cmd: "-rn", Args: []string{"key", "newkey"}}, false},
+		{"4. Pass in -rn.", []string{"ft", "-rn", "key", "newKey"}, &Cmd{Cmd: "-rn", Args: []string{"key", "newKey"}}, false},
 		{"5. pass in -set.", []string{"ft", "-set", "key"}, &Cmd{Cmd: "-set", Args: []string{"key"}}, false},
 		{"6. pass in invalid command.", []string{"ft", "-invalid"}, nil, true},
 		{"7. pass in not enough arguments for -rn.", []string{"ft", "-rn"}, nil, true},
@@ -51,12 +68,12 @@ func TestPassCmd(t *testing.T) {
 	for _, tt := range tests {
 		got, err := PassCmd(tt.args)
 		if (err != nil) != tt.wantErr {
-			fmt.Println(tt.name)
+			t.Log(tt.name)
 			t.Errorf("passCmd err %v, want err: %v", err, tt.wantErr)
 		}
-		if !tt.wantErr && !cmp.Equal(got, tt.want) {
-			fmt.Println(tt.name)
-			t.Errorf("passCmd Args: %v\nexpected: %v\ngot:%v\n_________\n", tt.args, tt.want, got)
+		if !tt.wantErr && !equalCmd(tt.want, got) {
+			t.Log(tt.name)
+			t.Errorf("passCmd Args: %v\nexpected: %v\ngot: %v\n_________\n", tt.args, tt.want, got)
 		}
 
 	}

--- a/ft/commands_test.go
+++ b/ft/commands_test.go
@@ -748,11 +748,15 @@ func TestNavStack(t *testing.T) {
 func TestUpdateFT(t *testing.T) {
 	// Mock server to simulate GitHub API responses
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("Received request: %v", r)
 		tag := strings.TrimPrefix(r.URL.Path, "/repos/osteensco/fastTravelCLI/")
+		t.Logf("tag: %v", tag)
 		if tag == "releases/latest" {
+			t.Logf("releases/latest: %v", true)
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(map[string]string{"tag_name": "v.0.2.0"})
 		} else if tag == "tags/v.0.1.3" {
+			t.Logf("tags/v.0.1.3: %v", true)
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(map[string]string{"tag_name": "v.0.1.3"})
 
@@ -776,6 +780,7 @@ func TestUpdateFT(t *testing.T) {
 	// Override endpoint URL to use the test server
 	EndpointGH = server.URL + "/repos/osteensco/fastTravelCLI/tags/%s"
 	EndpointLatestGH = server.URL + "/repos/osteensco/fastTravelCLI/releases/latest"
+
 	// Override Git related constants for testing
 	GitCloneCMD = []string{"echo", "'", "mocking", "version", "", "git", "clone", "dev", "'"}
 	GitCloneDir = strings.TrimSuffix(cwd, "/ft")
@@ -794,18 +799,18 @@ func TestUpdateFT(t *testing.T) {
 		},
 		{
 			name:      "2. Update with specific version.",
-			args:      []string{"update", "v.0.1.3"},
+			args:      []string{"v.0.1.3"},
 			wantError: false,
 		},
 		{
 			name:       "3. Already up-to-date version.",
-			args:       []string{"update", "latest"},
+			args:       []string{"latest"},
 			wantError:  false,
 			setVersion: func() { Version = "v.0.2.0" },
 		},
 		{
 			name:      "4. Nonexistent version.",
-			args:      []string{"update", "nonexistentversionnumber"},
+			args:      []string{"nonexistentversionnumber"},
 			wantError: true,
 		},
 	}
@@ -813,6 +818,7 @@ func TestUpdateFT(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Log(tt.name)
+			t.Log(server.URL)
 
 			if tt.setVersion != nil {
 				defaultVersion = Version

--- a/ft/constants.go
+++ b/ft/constants.go
@@ -20,7 +20,7 @@ func NewCmdAPI(ftDir string, inputCmd *Cmd, allPaths map[string]string, file *os
 
 // struct used to identify flags that were provided with a given command
 type CmdFlags struct {
-	y bool
+	Y bool
 }
 
 // struct used to dissect and organize a command into it's individual components
@@ -33,7 +33,7 @@ type Cmd struct {
 func NewCmd(args *[]string) *Cmd {
 	return &Cmd{
 		// flags and cmd will be empty defaults
-		// args is explicit so that enough space is allocated to unerlying array for slight optimization
+		// args is explicit so that enough space is allocated to underlying array for slight optimization
 		Args: make([]string, 0, len(*args)),
 	}
 }

--- a/ft/constants.go
+++ b/ft/constants.go
@@ -6,26 +6,46 @@ import (
 )
 
 // ft command api
-type CmdArgs struct {
+type CmdAPI struct {
 	wkDir    string
-	cmd      []string
+	cmd      *Cmd
 	allPaths map[string]string
 	file     *os.File
 	rdr      io.Reader
 }
 
-func NewCmdArgs(ftDir string, inputCmd []string, allPaths map[string]string, file *os.File, rdr io.Reader) *CmdArgs {
-	return &CmdArgs{ftDir, inputCmd, allPaths, file, rdr}
+func NewCmdAPI(ftDir string, inputCmd *Cmd, allPaths map[string]string, file *os.File, rdr io.Reader) *CmdAPI {
+	return &CmdAPI{ftDir, inputCmd, allPaths, file, rdr}
+}
+
+// struct used to identify flags that were provided with a given command
+type CmdFlags struct {
+	y bool
+}
+
+// struct used to dissect and organize a command into it's individual components
+type Cmd struct {
+	Flags CmdFlags
+	Cmd   string
+	Args  []string
+}
+
+func NewCmd(args *[]string) *Cmd {
+	return &Cmd{
+		// flags and cmd will be empty defaults
+		// args is explicit so that enough space is allocated to unerlying array for slight optimization
+		Args: make([]string, 0, len(*args)),
+	}
 }
 
 // map of available commands
 var AvailCmds = map[string]struct {
-	Callback func(data *CmdArgs) error
+	Callback func(data *CmdAPI) error
 	LoadData bool
 }{
 	"_":        {changeDirectory, true},
 	"-set":     {setDirectoryVar, true},
-	"-setf":    {setDirectoryVar, true},
+	"-setf":    {setDirectoryVar, true}, // TODO delete me
 	"-ls":      {displayAllPaths, true},
 	"-rm":      {removeKey, true},
 	"-rn":      {renameKey, true},

--- a/ft/constants.go
+++ b/ft/constants.go
@@ -45,7 +45,6 @@ var AvailCmds = map[string]struct {
 }{
 	"_":        {changeDirectory, true},
 	"-set":     {setDirectoryVar, true},
-	"-setf":    {setDirectoryVar, true}, // TODO delete me
 	"-ls":      {displayAllPaths, true},
 	"-rm":      {removeKey, true},
 	"-rn":      {renameKey, true},
@@ -67,7 +66,6 @@ var AvailCmds = map[string]struct {
 var CmdDesc = map[string]string{
 	"key":      "change directory to provided key's path - Usage: ft [key]",
 	"-set":     "set key to a directory path, if no directory path is given attempts to set key to CWD - Usage: ft -set [key], ft -set [key]=[path]",
-	"-setf":    "force set key to a directory path, if no directory path is given force set key to CWD - Usage: ft -setf [key], ft -setf [key]=[path]",
 	"-ls":      "display all current key value pairs - Usage: ft -ls",
 	"-rm":      "deletes provided key - Usage: ft -rm [key]",
 	"-rn":      "renames key to new key - Usage: ft -rn [key] [new key]",
@@ -118,4 +116,7 @@ const (
 	AbortRenameKeyMsg         = "Aborted renaming of key '%s' to '%s'. \n"
 	IsKeyMsg                  = "Directory %s is saved to key : %s. \n"
 	IsNotKeyMsg               = "No key was found for the specified path: %s. \n"
+	VerifyEditMsg             = "Are you sure you want to change '%s: %s' to '%s: %s'? (y/n) \n"
+	AbortEditMsg              = "Aborted replacing '%s: %s' with '%s: %s'. \n"
+	PathIsNotValidDirWarn     = "Warning: Path %s is not a valid directory. \n"
 )

--- a/ft/helpers.go
+++ b/ft/helpers.go
@@ -140,7 +140,7 @@ func ParseArgs(args *[]string) *Cmd {
 			}
 			continue
 		} else {
-			// hadnle special navigation commands
+			// handle special navigation commands
 			switch v {
 			case "]", "[", "..", "-":
 				if cmd.Cmd == "" {

--- a/ft/helpers.go
+++ b/ft/helpers.go
@@ -116,7 +116,12 @@ func PipeArgs(args *[]string) error {
 // Parses os.Args and organizes command into a struct
 func ParseArgs(args *[]string) *Cmd {
 	cmd := NewCmd(args)
-	for _, v := range *args {
+	for i, v := range *args {
+		if i == 0 {
+			// the first arg should always correspond to the shell's function call
+			// we don't explicitly check the function call (default 'ft') since a user could potentially use an alias or wrap it in another call
+			continue
+		}
 		// command and flags will have the '-' prefix
 		// acts as a 'permissive' checker
 		if v[0] == '-' {
@@ -135,8 +140,16 @@ func ParseArgs(args *[]string) *Cmd {
 			}
 			continue
 		} else {
+			// hadnle special navigation commands
+			switch v {
+			case "]", "[", "..", "-":
+				if cmd.Cmd == "" {
+					cmd.Cmd = v
+				}
+			default:
 
-			cmd.Args = append(cmd.Args, v)
+				cmd.Args = append(cmd.Args, v)
+			}
 		}
 	}
 

--- a/ft/helpers.go
+++ b/ft/helpers.go
@@ -123,7 +123,7 @@ func ParseArgs(args *[]string) *Cmd {
 			v = strings.ToLower(v)
 			switch v {
 			case "-y":
-				cmd.Flags.y = true
+				cmd.Flags.Y = true
 			default:
 				// if not a valid flag, we assume it's a command
 				// validity of command is checked elsewhere

--- a/ft/helpers.go
+++ b/ft/helpers.go
@@ -112,3 +112,33 @@ func PipeArgs(args *[]string) error {
 	return nil
 
 }
+
+// Parses os.Args and organizes command into a struct
+func ParseArgs(args *[]string) *Cmd {
+	cmd := NewCmd(args)
+	for _, v := range *args {
+		// command and flags will have the '-' prefix
+		// acts as a 'permissive' checker
+		if v[0] == '-' {
+			v = strings.ToLower(v)
+			switch v {
+			case "-y":
+				cmd.Flags.y = true
+			default:
+				// if not a valid flag, we assume it's a command
+				// validity of command is checked elsewhere
+				// first command found is the one identified for use
+				if cmd.Cmd != "" {
+					continue
+				}
+				cmd.Cmd = v
+			}
+			continue
+		} else {
+
+			cmd.Args = append(cmd.Args, v)
+		}
+	}
+
+	return cmd
+}

--- a/ft/helpers_test.go
+++ b/ft/helpers_test.go
@@ -186,3 +186,7 @@ func TestPipeArgs(t *testing.T) {
 	}
 
 }
+
+func TestParseArgs(t *testing.T) {
+	// TODO implement
+}

--- a/ft/helpers_test.go
+++ b/ft/helpers_test.go
@@ -49,15 +49,15 @@ func TestVerifyInput(t *testing.T) {
 		name     string
 		expected bool
 		force    bool
-		data     CmdArgs
+		data     CmdAPI
 		wantErr  bool
 	}{
 		{
 			name:     "1. User inputs 'y'.",
 			expected: true,
 			force:    false,
-			data: CmdArgs{
-				cmd:      []string{},
+			data: CmdAPI{
+				cmd:      nil,
 				allPaths: map[string]string{},
 				file:     nil,
 				rdr:      strings.NewReader("y"),
@@ -68,8 +68,8 @@ func TestVerifyInput(t *testing.T) {
 			name:     "2. User inputs 'n'.",
 			expected: false,
 			force:    false,
-			data: CmdArgs{
-				cmd:      []string{},
+			data: CmdAPI{
+				cmd:      nil,
 				allPaths: map[string]string{},
 				file:     nil,
 				rdr:      strings.NewReader("n"),
@@ -80,8 +80,8 @@ func TestVerifyInput(t *testing.T) {
 			name:     "3. User inputs invalid option.",
 			expected: false,
 			force:    false,
-			data: CmdArgs{
-				cmd:      []string{},
+			data: CmdAPI{
+				cmd:      nil,
 				allPaths: map[string]string{},
 				file:     nil,
 				rdr:      strings.NewReader("x\n"),
@@ -92,8 +92,8 @@ func TestVerifyInput(t *testing.T) {
 			name:     "4. User uses force option.",
 			expected: true,
 			force:    true,
-			data: CmdArgs{
-				cmd:      []string{},
+			data: CmdAPI{
+				cmd:      nil,
 				allPaths: map[string]string{},
 				file:     nil,
 				rdr:      strings.NewReader("n"),

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/osteensco/fastTravelCLI
 
-go 1.20
+go 1.21
+
+toolchain go1.23.4
+
+require github.com/google/go-cmp v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/osteensco/fastTravelCLI
 go 1.21
 
 toolchain go1.23.4
-
-require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
-github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 		fmt.Println("Error: ", err)
 		return
 	}
-	action := inputCommand[0]
+	action := inputCommand.Cmd
 
 	// grab command from registry
 	cmd, ok := ft.AvailCmds[action]
@@ -66,7 +66,7 @@ func main() {
 	}
 
 	// manifest API
-	data := ft.NewCmdArgs(dataDirPath, inputCommand, allPaths, file, os.Stdin)
+	data := ft.NewCmdAPI(dataDirPath, inputCommand, allPaths, file, os.Stdin)
 
 	// execute user provided action
 	err = cmd.Callback(data)

--- a/main_test.go
+++ b/main_test.go
@@ -165,7 +165,7 @@ func TestMainFunc(t *testing.T) {
 		},
 		{
 			name:     "10. Check force set command.",
-			args:     []string{"ft", "-setf", fmt.Sprintf("key=%v", forcedir)},
+			args:     []string{"ft", "-set", "-y", fmt.Sprintf("key=%v", forcedir)},
 			expected: fmt.Sprintf(ft.AddKeyMsg, "key", forcedir),
 			wantErr:  false,
 		},

--- a/main_test.go
+++ b/main_test.go
@@ -91,7 +91,7 @@ func TestMainFunc(t *testing.T) {
 			// TODO
 			//  - generate this string dynamically?
 			expected: fmt.Sprintf(
-				"\n-edit: %s\n-help: %s\n-hist: %s\n-is: %s\n-ls: %s\n-rm: %s\n-rn: %s\n-set: %s\n-setf: %s\n-update: %s\n-version: %s\n[: %s\n]: %s\nkey: %s\n\n",
+				"\n-edit: %s\n-help: %s\n-hist: %s\n-is: %s\n-ls: %s\n-rm: %s\n-rn: %s\n-set: %s\n-update: %s\n-version: %s\n[: %s\n]: %s\nkey: %s\n\n",
 				ft.CmdDesc["-edit"],
 				ft.CmdDesc["-help"],
 				ft.CmdDesc["-hist"],
@@ -100,7 +100,6 @@ func TestMainFunc(t *testing.T) {
 				ft.CmdDesc["-rm"],
 				ft.CmdDesc["-rn"],
 				ft.CmdDesc["-set"],
-				ft.CmdDesc["-setf"],
 				ft.CmdDesc["-update"],
 				ft.CmdDesc["-version"],
 				ft.CmdDesc["["],


### PR DESCRIPTION
- Added -y flag to bypass user input on commands that have confirmation prompts
- Added logic to handle -y flag for said commands
- Removed -setf function as -y flag should be used instead
- Added ParseArgs function to more effectively organize different components of a command
- Added Cmd and CmdFlags structs
- Renamed CmdArgs to CmdAPI